### PR TITLE
Update NAB test API url

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ Further documentation is available from the [Fontis NAB Transact](http://www.fon
 ### Community Contributions
 
 1. [@ben_corlett](https://twitter.com/ben_corlett)
-2. Add your name here
+2. [@dimasdwika](https://twitter.com/dimasdwika)
+3. Add your name here

--- a/src/app/code/community/Fontis/Nab/Model/Transact.php
+++ b/src/app/code/community/Fontis/Nab/Model/Transact.php
@@ -36,7 +36,7 @@ class Fontis_Nab_Model_Transact extends Mage_Payment_Model_Method_Cc
 
     // Credit Card URLs
     const CC_URL_LIVE = 'https://transact.nab.com.au/live/xmlapi/payment';
-    const CC_URL_TEST = 'https://transact.nab.com.au/test/xmlapi/payment';
+    const CC_URL_TEST = 'https://demo.transact.nab.com.au/xmlapi/payment';
 
     const STATUS_APPROVED = 'Approved';
 


### PR DESCRIPTION
As per NAB upgrade demo site since 9 May 2017, the test url change to
use this v2 url.